### PR TITLE
Add workaround for missing content types in response fields, use correct affordance keys

### DIFF
--- a/tdd/__init__.py
+++ b/tdd/__init__.py
@@ -34,6 +34,7 @@ from tdd.errors import (
     JSONSchemaError,
     IDNotFound,
     WrongMimeType,
+    IncorrectlyDefinedParameter,
 )
 from tdd.td import (
     clear_expired_td,
@@ -109,9 +110,7 @@ def create_app():
     for entry_point in entry_points(group="tdd_api.plugins.blueprints"):
         try:
             app.register_blueprint(entry_point.load())
-            print(
-                f"Imported {entry_point.value} blueprint"
-            )
+            print(f"Imported {entry_point.value} blueprint")
         except Exception as exc:
             print(f"ERROR ({entry_point.name}): {exc}")
             print(
@@ -121,9 +120,7 @@ def create_app():
     for entry_point in entry_points(group="tdd_api.plugins.transformers"):
         try:
             TD_TRANSFORMERS.append(entry_point.load())
-            print(
-                f"Imported {entry_point.value} transformer"
-            )
+            print(f"Imported {entry_point.value} transformer")
         except Exception as exc:
             print(f"ERROR ({entry_point.name}): {exc}")
             print(
@@ -344,6 +341,9 @@ def register_routes(app):
                 f' etag="{get_collection_etag()}"'
             )
             return response
+        raise IncorrectlyDefinedParameter(
+            "'format' parameter is not recognized. Must be 'array' or 'collection' if defined."
+        )
 
     @app.route("/things/<id>", methods=["GET"])
     def describe_td(id):

--- a/tdd/common.py
+++ b/tdd/common.py
@@ -28,7 +28,6 @@ from tdd.sparql import (
     query,
 )
 from tdd.metadata import insert_metadata, delete_metadata
-from tdd.errors import IDNotFound
 from tdd.config import CONFIG
 
 
@@ -56,14 +55,11 @@ def json_ld_to_ntriples(ld_content):
     input_data = json.dumps(ld_content) + "\n"
     with resources.path("tdd.lib", "transform-to-nt.js") as transform_lib_path:
         p = subprocess.Popen(
-            [
-                "node",
-                transform_lib_path
-            ],
+            ["node", transform_lib_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True
+            universal_newlines=True,
         )
         p.stdin.write(input_data)
         p.stdin.flush()
@@ -111,14 +107,11 @@ def frame_nt_content(nt_content, frame):
     input_data = json.dumps([ntriples, frame]) + "\n"
     with resources.path("tdd.lib", "frame-jsonld.js") as frame_lib_path:
         p = subprocess.Popen(
-            [
-                "node",
-                frame_lib_path
-            ],
+            ["node", frame_lib_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True
+            universal_newlines=True,
         )
         p.stdin.write(input_data)
         p.stdin.flush()
@@ -136,6 +129,6 @@ def get_id_description(uri, content_type, ontology):
     if not resp.text.strip() or not (
         re.search(r"^[^\#]", resp.text, re.MULTILINE)
     ):  # because some SPARQL endpoint may send "# Empty file" as response
-        #raise IDNotFound()
+        # raise IDNotFound()
         abort(404)
     return resp.text

--- a/tdd/data/tdd-description.json
+++ b/tdd/data/tdd-description.json
@@ -10,7 +10,7 @@
   "security": "no_sec",
   "base": "{{TD_REPO_URL}}",
   "actions": {
-    "createTD": {
+    "createThing": {
       "description": "Create a Thing Description",
       "uriVariables": {
         "id": {
@@ -63,7 +63,7 @@
         }
       ]
     },
-    "updateTD": {
+    "updateThing": {
       "description": "Update a Thing Description",
       "uriVariables": {
         "id": {
@@ -109,7 +109,7 @@
         }
       ]
     },
-    "deleteTD": {
+    "deleteThing": {
       "description": "Delete a Thing Description",
       "uriVariables": {
         "id": {

--- a/tdd/data/tdd-description.json
+++ b/tdd/data/tdd-description.json
@@ -187,7 +187,7 @@
       },
       "forms": [
         {
-          "href": "/things?format={format}&offset={offset}&limit={limit}",
+          "href": "/things{?offset,limit,format}",
           "htv:methodName": "GET",
           "response": {
             "description": "Success response",

--- a/tdd/data/tdd-description.json
+++ b/tdd/data/tdd-description.json
@@ -139,7 +139,7 @@
     }
   },
   "properties": {
-    "retrieveTD": {
+    "retrieveThing": {
       "description": "Retrieve a Thing Description",
       "uriVariables": {
         "id": {
@@ -168,7 +168,7 @@
         }
       ]
     },
-    "retrieveTDs": {
+    "things": {
       "description": "Retrieve Thing Descriptions in batch",
       "uriVariables": {
         "format": {

--- a/tdd/errors.py
+++ b/tdd/errors.py
@@ -205,3 +205,7 @@ class WrongMimeType(AppException):
             f"Provided mimetype '{provided_mimetype}' is not supported. Only "
             f"{', '.join(POSSIBLE_MIMETYPES)}, application/json are allowed"
         )
+
+
+class IncorrectlyDefinedParameter(AppException):
+    title = "Incorrectly defined parameter"

--- a/tdd/sparql.py
+++ b/tdd/sparql.py
@@ -212,7 +212,7 @@ def query(
                 sparqlendpoint,
                 data={"update": querystring},
             )
-    
+
     if resp.status_code not in status_codes:
         raise FusekiError(resp)
     return resp

--- a/tdd/tests/conftest.py
+++ b/tdd/tests/conftest.py
@@ -98,13 +98,13 @@ class SparqlGraph:
 
 @pytest.fixture
 def mock_sparql_with_one_td(httpx_mock):
-    graph = SparqlGraph("smart_coffe_machine_init.nquads")
+    graph = SparqlGraph("smart_coffee_machine_init.nquads")
     httpx_mock.add_callback(graph.custom)
 
 
 @pytest.fixture
 def mock_sparql_with_one_expired_td(httpx_mock):
-    graph = SparqlGraph("smart_coffe_machine_expired.nquads")
+    graph = SparqlGraph("smart_coffee_machine_expired.nquads")
     httpx_mock.add_callback(graph.custom)
 
 

--- a/tdd/tests/data/tdd-description.json
+++ b/tdd/tests/data/tdd-description.json
@@ -10,7 +10,7 @@
   "security": "no_sec",
   "base": "http://localhost:5050",
   "actions": {
-    "createTD": {
+    "createThing": {
       "description": "Create a Thing Description",
       "uriVariables": {
         "id": {
@@ -63,7 +63,7 @@
         }
       ]
     },
-    "updateTD": {
+    "updateThing": {
       "description": "Update a Thing Description",
       "uriVariables": {
         "id": {
@@ -109,7 +109,7 @@
         }
       ]
     },
-    "deleteTD": {
+    "deleteThing": {
       "description": "Delete a Thing Description",
       "uriVariables": {
         "id": {

--- a/tdd/tests/data/tdd-description.json
+++ b/tdd/tests/data/tdd-description.json
@@ -187,7 +187,7 @@
       },
       "forms": [
         {
-          "href": "/things?format={format}&offset={offset}&limit={limit}",
+          "href": "/things{?offset,limit,format}",
           "htv:methodName": "GET",
           "response": {
             "description": "Success response",

--- a/tdd/tests/data/tdd-description.json
+++ b/tdd/tests/data/tdd-description.json
@@ -139,7 +139,7 @@
     }
   },
   "properties": {
-    "retrieveTD": {
+    "retrieveThing": {
       "description": "Retrieve a Thing Description",
       "uriVariables": {
         "id": {
@@ -168,7 +168,7 @@
         }
       ]
     },
-    "retrieveTDs": {
+    "things": {
       "description": "Retrieve Thing Descriptions in batch",
       "uriVariables": {
         "format": {


### PR DESCRIPTION
This PR includes the workaround needed to resolve #13. It is based on a similar PR (https://github.com/vaimee/zion/pull/52) I submitted to ZION dealing with the same issue.

While working on this issue, I noticed that the TDD's TD did not use the correct affordance keys to be compliant with the Discovery specification (c.f. the Thing Model in [section 7.3.2.4](https://www.w3.org/TR/wot-discovery/#directory-api-spec)). Therefore, I also adjusted the keys to improve the directory's interoperability.

