### PR TITLE
feat: add Eclipse Thingweb logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Domus TDD API
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/domus_for_dark_bg.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/domus.svg">
+    <img title="Eclipse Thingweb Domus TDD API" alt="Domus logo" src="https://raw.githubusercontent.com/eclipse-thingweb/thingweb/main/brand/logos/domus.svg" width="300">
+  </picture>
+  <br>
+  Domus TDD API
+</h1>
 
 A Python and SPARQL based Thing Description Directory API compliant to:
 https://www.w3.org/TR/wot-discovery/


### PR DESCRIPTION
I have added the Eclipse ThingWeb logo to the readme to follow established patterns

Closes #18 