### PR TITLE
fix(scripts): explicitly declare utf-8 encoding for cross-platform file I/O

### DIFF
--- a/scripts/import_all_plugfest.py
+++ b/scripts/import_all_plugfest.py
@@ -23,7 +23,7 @@ client = httpx.Client(timeout=60.0)
 
 def upload_file(filepath):
     print(f"Uploading {filepath} ... ", end="")
-    with open(filepath) as fp:
+    with open(filepath, encoding="utf-8") as fp:
         data = fp.read()
         r = client.post(
             sys.argv[2], data=data, headers={"Content-Type": "application/json"}


### PR DESCRIPTION
### Summary
This PR fixes a `UnicodeDecodeError` that occurs when running the `import_all_plugfest.py` script on Windows environments.

### Motivation
While setting up the local development environment as a prospective **GSoC 2026 contributor**, I encountered a crash during the database seeding process. On Windows, the `open()` function defaults to the OS's native encoding (typically `cp1252`), which fails to decode multibyte UTF-8 characters present in some Thing Description (TD) files, such as `tum-light1.td.jsonld`.

### Changes
- Refactored `scripts/import_all_plugfest.py` to explicitly use `encoding="utf-8"` in the `open()` function.
- This ensures **Platform-Agnostic** behavior, allowing the script to run seamlessly across macOS, Linux, and Windows without relying on implicit system defaults.

### Verification Results (Closed-Loop Validation)
I have successfully verified this fix on a Windows 11 environment:
1. **Before Fix:** The script crashed with `UnicodeDecodeError` at file 16/23.
2. **After Fix:** All 23 TD files in `tdd/tests/data/td/17_TD_RAW` were imported successfully (`ok` status for all).
3. **Data Integrity:** Verified the imported data via the SPARQL endpoint at `localhost:3030`, confirming that the triples were correctly persisted in the `/things` dataset.

I am excited to continue exploring the codebase, specifically focusing on the integration of MCP servers and LLM-based querying for Digital Twins!

### Checklist
- [x] I have signed the Eclipse Contributor Agreement (ECA).
- [x] My commit is signed-off (`git commit -s`).